### PR TITLE
Add method to return response to http request

### DIFF
--- a/src/GenerativeArtNFT/Http.mo
+++ b/src/GenerativeArtNFT/Http.mo
@@ -1,0 +1,69 @@
+import Blob "mo:base/Blob";
+import Option "mo:base/Option";
+import Text "mo:base/Text";
+import Iter "mo:base/Iter";
+import List "mo:base/List";
+
+module Types {
+  
+  public type HeaderField = (Text, Text);
+
+  public type HttpRequest = {
+    body: Blob;
+    headers: [HeaderField];
+    method: Text;
+    url: Text;
+  };
+
+  public type HttpResponse = {
+    body: Blob;
+    headers: [HeaderField];
+    status_code: Nat16;
+  };
+
+  public type Query = {
+    key: Text;
+    value: Text;
+  };
+
+  // Remove query (e.g. url parameters)
+  public func removeQuery(str: Text): Text {
+    switch (Text.split(str, #char '?').next()) {
+      case null { "/" };
+      case (?t) { t };
+    }
+  };
+
+  // Extract query (or remove path)
+  public func extractQuery(str: Text): Text {
+    let s = Text.split(str, #char '?');
+    // Remove path
+    let path = s.next();
+    switch (s.next()) {
+      case null { "" };
+      case (?q) { q }; 
+    }
+  };
+
+  // Return a list of query (key-value pair)
+  public func queryParameters(str: Text): List.List<Query> {
+    let queryText = extractQuery(str);
+
+    let pairs = Iter.filter<Text>(Text.split(queryText, #char '&'), func (t) {
+      Text.contains(t, #char '=')
+    });
+
+    Iter.toList(Iter.map<Text, Query>(pairs, func (t: Text) {
+      let s = Text.split(t, #char '=');
+      let key = switch (s.next()) {
+        case null { "" };
+        case (?k) { k };
+      };
+      let value = switch (s.next()) {
+        case null { "" };
+        case (?v) { v };
+      };
+      { key = key; value = value }
+    }))
+  };
+}

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did
@@ -62,6 +62,24 @@ type Metadata =
    nonfungible: record {metadata: opt blob;};
  };
 type Memo = blob;
+type HttpResponse = 
+ record {
+   body: blob;
+   headers: vec HeaderField;
+   status_code: nat16;
+ };
+type HttpRequest = 
+ record {
+   body: blob;
+   headers: vec HeaderField;
+   method: text;
+   url: text;
+ };
+type HeaderField = 
+ record {
+   text;
+   text;
+ };
 type GenerativeArtNFT = 
  service {
    acceptCycles: () -> ();
@@ -83,6 +101,7 @@ type GenerativeArtNFT =
                            TokenIndex;
                            Metadata;
                          }) query;
+   http_request: (HttpRequest) -> (HttpResponse) query;
    metadata: (TokenIdentifier__1) -> (Result_1) query;
    mintNFT: (MintRequest) -> (TokenIndex);
    supply: (TokenIdentifier__1) -> (Result) query;

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
@@ -33,10 +33,23 @@ export interface GenerativeArtNFT {
   'getAllowances' : () => Promise<Array<[TokenIndex, Principal]>>,
   'getRegistry' : () => Promise<Array<[TokenIndex, AccountIdentifier__1]>>,
   'getTokens' : () => Promise<Array<[TokenIndex, Metadata]>>,
+  'http_request' : (arg_0: HttpRequest) => Promise<HttpResponse>,
   'metadata' : (arg_0: TokenIdentifier__1) => Promise<Result_1>,
   'mintNFT' : (arg_0: MintRequest) => Promise<TokenIndex>,
   'supply' : (arg_0: TokenIdentifier__1) => Promise<Result>,
   'transfer' : (arg_0: TransferRequest) => Promise<TransferResponse>,
+}
+export type HeaderField = [string, string];
+export interface HttpRequest {
+  'url' : string,
+  'method' : string,
+  'body' : Array<number>,
+  'headers' : Array<HeaderField>,
+}
+export interface HttpResponse {
+  'body' : Array<number>,
+  'headers' : Array<HeaderField>,
+  'status_code' : number,
 }
 export type Memo = Array<number>;
 export type Metadata = {

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.js
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.js
@@ -53,6 +53,18 @@ export const idlFactory = ({ IDL }) => {
     }),
     'nonfungible' : IDL.Record({ 'metadata' : IDL.Opt(IDL.Vec(IDL.Nat8)) }),
   });
+  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'status_code' : IDL.Nat16,
+  });
   const Result_1 = IDL.Variant({ 'ok' : Metadata, 'err' : CommonError });
   const MintRequest = IDL.Record({
     'to' : User,
@@ -102,6 +114,7 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Tuple(TokenIndex, Metadata))],
         ['query'],
       ),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
     'metadata' : IDL.Func([TokenIdentifier__1], [Result_1], ['query']),
     'mintNFT' : IDL.Func([MintRequest], [TokenIndex], []),
     'supply' : IDL.Func([TokenIdentifier__1], [Result], ['query']),

--- a/src/tests/e2e/image.test.ts
+++ b/src/tests/e2e/image.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment node
+ */
+
+import fetch from 'isomorphic-fetch';
+import { generateTokenIdentifier } from '../../GenerativeArtNFT_assets/src/utils/ext';
+import localCanisterIds from '../../../.dfx/local/canister_ids.json';
+const canisterId = localCanisterIds.GenerativeArtNFT.local;
+
+describe('Http call', () => {
+  it('Request to the root path should return a text', async () => {
+    const res = await fetch(`http://localhost:8000?canisterId=${canisterId}`);
+    const text = await res.text();
+    expect(res.status).toBe(200);
+    expect(text).toBe('Generative Art NFT');
+  });
+
+  it('Return invalid token when specifying a wrong token id', async () => {
+    const wrongTokenId = 'm3uuh-zykor-uwiaa-aaaaa-beaag-maqca-aaaos-q';
+    const res = await fetch(
+      `http://localhost:8000?canisterId=${canisterId}&tokenid=${wrongTokenId}`
+    );
+    const text = await res.text();
+    expect(res.status).toBe(404);
+    expect(text).toBe(`Invalid token ${wrongTokenId}`);
+  });
+
+  it('Return token index when specifying a correct token id', async () => {
+    const tokenIndex = 1;
+    const correctTokenId = generateTokenIdentifier(canisterId, tokenIndex);
+    const res = await fetch(
+      `http://localhost:8000?canisterId=${canisterId}&tokenid=${correctTokenId}`
+    );
+    const text = await res.text();
+    expect(res.status).toBe(200);
+    expect(text).toBe(`Token index is ${tokenIndex}`);
+  });
+
+  it('Return token index even if an additional dummy query is specified', async () => {
+    const tokenIndex = 1;
+    const correctTokenId = generateTokenIdentifier(canisterId, tokenIndex);
+    const res = await fetch(
+      `http://localhost:8000?canisterId=${canisterId}&tokenid=${correctTokenId}&dummy=1`
+    );
+    const text = await res.text();
+    expect(res.status).toBe(200);
+    expect(text).toBe(`Token index is ${tokenIndex}`);
+  });
+});


### PR DESCRIPTION
# 概要・目的
GenerativeArtNFT Canister に、http リクエストに対してレスポンスを返すメソッドを追加する
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
関連 #7 

# 変更内容
## やったこと
- http関連の型とヘルパー関数を定義した `Http.mo` を作成
- main.mo に `http_request` 関数を追加し `tokenid` をクエリパラメータとする場合の処理を追加
- e2eテストを追加
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- GenerativeArtNFT Canister への画像の追加
- GenerativeArtNFT Canister から画像を返す
- Http.mo の unit test
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
GenerativeArtNFT Canister とテスト
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
```
./script/install_local.sh
npm run test
```
の正常終了を確認
<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
以下を参考に作成しました。
https://github.com/Toniq-Labs/creator-nfts/blob/main/canisters/nft/main.mo
ただし、[こちら](https://github.com/Toniq-Labs/creator-nfts/blob/main/canisters/nft/main.mo#L570)に
```
      // we should improve this extremely brittle query param processing. This relies on tokenId being the last query param.
```
とコメントがあるように、`tokenid` のクエリパラメータが最後に指定されている場合にしか動作しない処理になっているので、この部分を改良し、クエリのリストを返すメソッドである `queryParameters` を新たに追加しました。


<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
