### PR TITLE
Add error handling to invalid args

### DIFF
--- a/src/artGenerator/index.ts
+++ b/src/artGenerator/index.ts
@@ -4,6 +4,10 @@ import { genImages } from './sketch'
 const startIndex = parseInt(process.argv[2]);
 const endIndex = parseInt(process.argv[3]);
 
+if (isNaN(startIndex) || isNaN(endIndex)) {
+  throw 'You must specify two args as type of number.';
+}
+
 const imagesSaveDir = './dist';
 
 if (!fs.existsSync(imagesSaveDir)){

--- a/src/uploadImages/index.ts
+++ b/src/uploadImages/index.ts
@@ -3,6 +3,10 @@ import { upload } from './upload';
 const startIndex = parseInt(process.argv[2]);
 const endIndex = parseInt(process.argv[3]);
 
+if (isNaN(startIndex) || isNaN(endIndex)) {
+  throw 'You must specify two args as type of number.';
+}
+
 const imagesSaveDir = './dist';
 
 upload(startIndex, endIndex, imagesSaveDir);


### PR DESCRIPTION
# 概要・目的

<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #35

# 変更内容
## やったこと
- artGeneratorとuploadImagesの引数が指定されていない場合or数値以外が渡された場合のエラーハンドリングを追加

<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと

<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
- artGenerator
- uploadImages

<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
下記コマンド実行時に想定のエラーが返されることを確認。
```sh
npm run generate:images -start=10
npm run generate:images -end=11
npm run generate:images
npm run generate:images -start=aaa -end=bbb
npm run upload:images -start=10
npm run upload:images -end=11
npm run upload:images
npm run upload:images -start=aaa -end=bbb
```

<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
`upload:images`実行時に下記エラーが出るのは私だけですかね..?
(↑の動作確認は該当部分コメントアウトして行いました)
```
TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "file:///home/nor-code/codes/generative-art-nft/.dfx/local/canister_ids.json" needs an import assertion of type "json"
    at new NodeError (node:internal/errors:372:5)
    at validateAssertions (node:internal/modules/esm/assert:82:15)
    at defaultLoad (node:internal/modules/esm/load:24:3)
    at /home/nor-code/codes/generative-art-nft/node_modules/ts-node/src/esm.ts:255:45
    at async addShortCircuitFlag (/home/nor-code/codes/generative-art-nft/node_modules/ts-node/src/esm.ts:409:15)
    at async ESMLoader.load (node:internal/modules/esm/loader:407:20)
    at async ESMLoader.moduleProvider (node:internal/modules/esm/loader:326:11) {
  code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING'
}
```

追記
使用しているnodeのversionの違いによりそうですね..

> Import assertions were introduced in node v17.1.0 according to [this](https://nodejs.org/api/errors.html#err_import_assertion_type_missing), but became required after v17.5.0 (related to this change:[github.com/nodejs/node/pull/40785](https://github.com/nodejs/node/pull/40785)). Import assertions address a security concern ([v8.dev/features/import-assertions](https://v8.dev/features/import-assertions)) about trusting cross-origin imports.

https://stackoverflow.com/questions/70106880/err-import-assertion-type-missing-for-import-of-json-file

※自分は↓でした。
```sh
$ node --version
v17.7.1
```

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
