### PR TITLE
Change to upload one image at a time

### DIFF
--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
@@ -42,7 +42,7 @@ export interface GenerativeArtNFT {
   'supply' : (arg_0: TokenIdentifier__1) => Promise<Result_1>,
   'transfer' : (arg_0: TransferRequest) => Promise<TransferResponse>,
   'updateTokenImageSetter' : (arg_0: Principal) => Promise<Result>,
-  'getTokenIndexOwnedByUser' : (arg_0: User) => Promise<Array<[TokenIndex]>>,
+  'getTokenIndexOwnedByUser' : (arg_0: User) => Promise<Array<TokenIndex>>,
 }
 export type HeaderField = [string, string];
 export interface HttpRequest {

--- a/src/uploadImages/upload.ts
+++ b/src/uploadImages/upload.ts
@@ -35,15 +35,12 @@ const actorOfImageSetter = createGenerativeArtNFTActor(
   identityOptionOfImageSetter
 );
 
-const range = (start: number, end: number) =>
-  [...Array(end - start + 1)].map((_, idx) => start + idx);
-
 export const upload = async (
   startIndex: number,
   endIndex: number,
   imagesSaveDir: string
 ) => {
-  range(startIndex, endIndex).forEach(async (i: number) => {
+  for (let i = startIndex; i <= endIndex; i++) {
     const tokenid = generateTokenIdentifier(canisterId, i);
 
     console.log(
@@ -56,5 +53,5 @@ export const upload = async (
     if ('err' in res) {
       throw new Error(JSON.stringify(res.err));
     }
-  });
+  }
 };


### PR DESCRIPTION
# 概要・目的
画像をひとつずつアップロードするように修正
<!-- [必須] Pull Request の概要・目的を記載する -->

# 変更内容
## やったこと
- 一度に大量の画像をCanister にアップロードしようとするとエラーが出るため、画像をひとつずつアップロードするように修正した https://github.com/Japan-DfinityInfoHub/generative-art-nft/pull/40/commits/aefda5f2efa572c770920f1d31e8aef73c2805e6
- did.t.tsにミスがあったため修正した https://github.com/Japan-DfinityInfoHub/generative-art-nft/pull/40/commits/dec80020cb58a496b61a5b40c96121764e59a046
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと

<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
uploadImages
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
```
npm run upload:images -start=1 -end=100
```
<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
