### PR TITLE
Downsize NFT image to make loading faster

### DIFF
--- a/src/artGenerator/sketch.ts
+++ b/src/artGenerator/sketch.ts
@@ -37,7 +37,7 @@ const sketch = (startIndex: number, endIndex: number, imagesSaveDir: string) => 
       const randomSeedVal = getSlicedNum(26, 29); // 0~4096
       const noiseSeedVal = getSlicedNum(29, 32); // 0~4096
 
-      const canvas = p.createCanvas(500, 500);
+      const canvas = p.createCanvas(300, 300);
       p.background(backgroundColorV1, backgroundColorV2, backgroundColorV3, 255);
     
       p.randomSeed(randomSeedVal);


### PR DESCRIPTION
# 概要・目的
IC上にデプロイしてみたら、ロードがかなり重いことが判明した。
最も手っ取り早い対処法として、画像のサイズを下げる。

<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->

# 変更内容
## やったこと
* NFTの生成サイズを500x500ではなく300x300に下げる。

<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
IC上のcanisterにuploadした画像の更新
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
* NFT生成スクリプト
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
#6NFTで検証
* before(500x500)
461.9 kB (461,923 bytes)
* after(300x300)
189.5 kB (189,510 bytes)
<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
